### PR TITLE
Declare cloth config as a dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,4 +95,5 @@ modrinth {
     loaders.addAll("fabric", "quilt")
     changelog.set(rootProject.file("changelog.md").readText())
     syncBodyFrom.set(rootProject.file("README.md").readText())
+    required.project("cloth-config")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ group = maven_group
 val minecraft_version: String by project
 val loader_version: String by project
 val fabric_kotlin_version: String by project
+val cloth_config_version: String by project
 
 repositories {
     mavenCentral()
@@ -37,7 +38,6 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:$fabric_version")
     modImplementation("net.fabricmc:fabric-language-kotlin:$fabric_kotlin_version")
 
-    val cloth_config_version: String by project
     modApi("me.shedaniel.cloth:cloth-config-fabric:$cloth_config_version")
 
     val mod_menu_version: String by project
@@ -60,6 +60,7 @@ tasks {
                     "minecraft_version" to minecraft_version,
                     "loader_version" to loader_version,
                     "fabric_kotlin_version" to fabric_kotlin_version,
+                    "cloth_config_version" to cloth_config_version
                 )
             )
         }

--- a/src/main/kotlin/me/iru/timedisplay/TimeUtils.kt
+++ b/src/main/kotlin/me/iru/timedisplay/TimeUtils.kt
@@ -39,7 +39,7 @@ object TimeUtils {
         if(TimeDisplay.config.twelveClockMode) {
             "Ingame Time (${String.format("%02d", hour % 12)}:${String.format("%02d", min)}:${String.format("%02d", sec)} ${if(hour > 12) "PM" else "AM"})"
         } else {
-            "Ingame Time (${String.format("%02d", hour)}:${String.format("%02d", min)}:${String.format("%02d", sec)} )"
+            "Ingame Time (${String.format("%02d", hour)}:${String.format("%02d", min)}:${String.format("%02d", sec)})"
         }
     }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,8 @@
     "fabric": "*",
     "fabric-language-kotlin": ">=${fabric_kotlin_version}",
     "minecraft": ">=${minecraft_version}",
-    "java": ">=17"
+    "java": ">=17",
+    "cloth-config": ">=${cloth_config_version}"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Declare cloth config as a dependency in fabric.mod.json so the fabric dependency handler will notify the user if cloth config isn't installed instead of just crashing the game. Also add cloth config as a dependency in the modrinth task.
And also remove a trailing whitespace before a closing bracket because it was bugging me.